### PR TITLE
Write Link nginx configs using conatiner names + migrate old systems

### DIFF
--- a/plugins/hub/noteworthy/hub/__init__.py
+++ b/plugins/hub/noteworthy/hub/__init__.py
@@ -34,11 +34,10 @@ class HubController(NoteworthyPlugin):
         link_wg_port = link_node.attrs['NetworkSettings']['Ports']['18521/udp'][0]['HostPort']
         link_udp_proxy_port = link_node.attrs['NetworkSettings']['Ports']['18522/udp'][0]['HostPort']
         link_udp_proxy_port_2 = link_node.attrs['NetworkSettings']['Ports']['18523/udp'][0]['HostPort']
-        link_ip = link_node.attrs['NetworkSettings']['Networks']['noteworthy']['IPAddress']
         from noteworthy.nginx import NginxController
         nc = NginxController()
-        nc.add_tls_stream_backend(link_name, domain_regex, link_ip)
-        nc.set_http_proxy_pass(link_name, domain_regex, link_ip)
+        nc.add_tls_stream_backend(link_name, domain_regex, link_name)
+        nc.set_http_proxy_pass(link_name, domain_regex, link_name)
         return {
             "link_wg_endpoint": f"{os.environ['NOTEWORTHY_HUB']}:{link_wg_port}",
             "link_udp_proxy_endpoint": f"{os.environ['NOTEWORTHY_HUB']}:{link_udp_proxy_port}",

--- a/plugins/migration/noteworthy/migration/migrations/02_MigrateLinkIpsToLinkNames.py
+++ b/plugins/migration/noteworthy/migration/migrations/02_MigrateLinkIpsToLinkNames.py
@@ -1,0 +1,27 @@
+import os
+import time
+from pathlib import Path
+
+'''
+This migrations fixes: https://github.com/decentralabs/noteworthy/issues/17
+
+The fix forces the hub to use link container names instead of IPs in its nginx configuration.
+In order to migrate old links to the new system, we update cached SNI backends and sites-enabled records.
+'''
+
+def run_migration():
+    PROFILE_PATH = '/opt/noteworthy/profiles'
+    profile_dirs = os.listdir(PROFILE_PATH)
+    config_dirs = [os.path.join(PROFILE_PATH, d) for d in profile_dirs
+                   if d.startswith('.')]
+    # migrate nginx records for hubs
+    NGINX_DIR = '/opt/noteworthy/profiles/.nginx'
+    HUB_DIR = '/opt/noteworthy/profiles/.noteworthy-hub'
+    if (NGINX_DIR in config_dirs) and (HUB_DIR in config_dirs):
+        from noteworthy.nginx import NginxController
+        nc = NginxController()
+        backends = nc.get_link_set().get('backends')
+        for backend in backends:
+            if backend['name'].startswith('link'):
+                nc.store_link(backend['name'], backend['domain'], backend['name'])
+                nc.set_http_proxy_pass(backend['name'], backend['domain'], backend['name'])

--- a/plugins/migration/noteworthy/migration/migrations/02_MigrateLinkIpsToLinkNames.py
+++ b/plugins/migration/noteworthy/migration/migrations/02_MigrateLinkIpsToLinkNames.py
@@ -24,4 +24,4 @@ def run_migration():
         for backend in backends:
             if backend['name'].startswith('link'):
                 nc.store_link(backend['name'], backend['domain'], backend['name'])
-                nc.set_http_proxy_pass(backend['name'], backend['domain'], backend['name'])
+                nc.set_http_proxy_pass(backend['name'], backend['domain'], backend['name'], reload: False)

--- a/plugins/migration/noteworthy/migration/migrations/02_MigrateLinkIpsToLinkNames.py
+++ b/plugins/migration/noteworthy/migration/migrations/02_MigrateLinkIpsToLinkNames.py
@@ -24,4 +24,6 @@ def run_migration():
         for backend in backends:
             if backend['name'].startswith('link'):
                 nc.store_link(backend['name'], backend['domain'], backend['name'])
-                nc.set_http_proxy_pass(backend['name'], backend['domain'], backend['name'], reload: False)
+                nc.set_http_proxy_pass(backend['name'], backend['domain'], backend['name'], reload = False)
+        bk = nc.get_link_set()
+        nc.write_config(bk)

--- a/plugins/nginx/noteworthy/nginx/__init__.py
+++ b/plugins/nginx/noteworthy/nginx/__init__.py
@@ -164,17 +164,27 @@ class NginxController(NoteworthyPlugin):
 
     def store_link(self, app_name: str, domain: str, ip_addr: str):
         link = { 'domain': f'{domain}',
-                    'endpoint': f'{ip_addr}:443'}
+                 'endpoint': f'{ip_addr}:443',
+                 'name': f'{app_name}'}
 
         with open(os.path.join(self.tls_backend_dir, f'{app_name}.yaml'), 'w') as link_file:
             link_file.write(yaml.dump(link))
 
     def get_link_set(self):
 
-        links = [ self.read_yaml_file(os.path.join(self.tls_backend_dir, link_file))
+        links = [ self.get_link(link_file)
                     for link_file in os.listdir(self.tls_backend_dir) ]
         return {
             'backends': links
         }
+
+    def get_link(self, link_file: str):
+        record = self.read_yaml_file(os.path.join(self.tls_backend_dir, link_file))
+        if(record.get('name')):
+            return record
+        # generate a name for links that did not have a name
+        name = os.path.splitext(link_file)[0]
+        record['name'] = name
+        return record
 
 Controller = NginxController

--- a/plugins/nginx/noteworthy/nginx/__init__.py
+++ b/plugins/nginx/noteworthy/nginx/__init__.py
@@ -105,7 +105,7 @@ class NginxController(NoteworthyPlugin):
         self._reload()
 
     def set_http_proxy_pass(self, app_name: str, domain: str, ip_addr: str,
-        template_path: str = None):
+        template_path: str = None, reload: bool = True):
         '''
         add new "virtualhost" site to nginx (ie noteworthy app)
         <app>.conf to nginx_sites_enabled
@@ -119,7 +119,8 @@ class NginxController(NoteworthyPlugin):
             output_file.write(rendered_config)
         with open(os.path.join(self.sites_dir, f'{app_name}.conf'), 'w') as output_file:
             output_file.write(rendered_config)
-        self._reload()
+        if reload:
+            self._reload()
 
     def add_tls_stream_backend(self, app_name: str, domain: str, ip_addr: str):
         self.store_link(app_name, domain, ip_addr)

--- a/plugins/nginx/noteworthy/nginx/deploy/nginx.gateway.tmpl.conf
+++ b/plugins/nginx/noteworthy/nginx/deploy/nginx.gateway.tmpl.conf
@@ -4,8 +4,8 @@ pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 stream {
 
-  {% for backend in backends}
-  upstream {{ backend.name }}{
+  {% for backend in backends %}
+  upstream {{ backend.name }} {
     server {{ backend.endpoint }};
   }
   {% endfor %}

--- a/plugins/nginx/noteworthy/nginx/deploy/nginx.gateway.tmpl.conf
+++ b/plugins/nginx/noteworthy/nginx/deploy/nginx.gateway.tmpl.conf
@@ -4,9 +4,15 @@ pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 stream {
 
+  {% for backend in backends}
+  upstream {{ backend.name }}{
+    server {{ backend.endpoint }};
+  }
+  {% endfor %}
+
   map $ssl_preread_server_name $targetBackend {
 	{% for backend in backends %}
-	{{ backend.domain }}	{{ backend.endpoint }};
+	{{ backend.domain }}	{{ backend.name }};
 	{% endfor %}
   }
 


### PR DESCRIPTION
# problem
This PR addresses [Issue 17](https://github.com/decentralabs/noteworthy/issues/17)
# solution
Since hubs are using docker's networking, we can use explicit names for nginx reverse-proxy + SNI configuration.

- hub now uses container names to configure nginx routing
- `nginx.conf` template now includes explicit `upstream` blocks for links
- new migration script updates configuration on old deployments

# TODO
- We need to add a step in our CI process for testing migrations of diff versions of our app.
- CI should cover more failure/recover modes
- We should do an internal network audit of hub and launcher containers.