### PR TITLE
Add workaround for GNU Make 4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 build/
 dist/
 *.egg-info/
+.dev-last-build

--- a/Makefile
+++ b/Makefile
@@ -19,26 +19,26 @@ help:
 	@echo
 
 test:
-	./run-tests.sh
+	./run-tests.sh ;
 
 integration-test:
-	HUB_IP=$(HUB_IP) ./notectl/run-tests.sh integration
+	HUB_IP=$(HUB_IP) ./notectl/run-tests.sh integration ;
 
 gatling:
-	docker run --network noteworthy --rm -it -v $(ROOT_DIR)/perftest/gatling/user-files:/opt/gatling/user-files -v $(ROOT_DIR)/perftest/gatling/results:/opt/gatling/results --name noteworthy-gatling-$(shell date +"%H-%M_%m-%d") denvazh/gatling -s $(SIM_NAME)
+	docker run --network noteworthy --rm -it -v $(ROOT_DIR)/perftest/gatling/user-files:/opt/gatling/user-files -v $(ROOT_DIR)/perftest/gatling/results:/opt/gatling/results --name noteworthy-gatling-$(shell date +"%H-%M_%m-%d") denvazh/gatling -s $(SIM_NAME) ;
 
 docker:
-	docker build --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg RELEASE_TAG=$(RELEASE_TAG) -t decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG) -f Dockerfile.$(ROLE) .
+	docker build --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg RELEASE_TAG=$(RELEASE_TAG) -t decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG) -f Dockerfile.$(ROLE) . ;
 
 docker-push:
-	echo ${DOCKERHUB_PSW}| docker login -u ${DOCKERHUB_USR} --password-stdin
-	docker tag decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG) decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG)-$(GIT_COMMIT)
-	docker push decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG)
-	docker push decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG)-$(GIT_COMMIT)
+	echo ${DOCKERHUB_PSW}| docker login -u ${DOCKERHUB_USR} --password-stdin ;
+	docker tag decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG) decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG)-$(GIT_COMMIT) ;
+	docker push decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG) ;
+	docker push decentralabs/noteworthy:$(ROLE)-$(RELEASE_TAG)-$(GIT_COMMIT) ;
 
 .dev-last-build: requirements.base.txt requirements.dev.txt
-	docker build -t noteworthy:dev -f Dockerfile.dev .
-	echo $(shell date) > .dev-last-build
+	docker build -t noteworthy:dev -f Dockerfile.dev . ;
+	echo $(shell date) > .dev-last-build ;
 
 dev shell: .dev-last-build
-	docker run --network noteworthy --rm -it -v /usr/local/bin/docker:/usr/local/bin/docker -v /var/run/docker.sock:/var/run/docker.sock -v $(ROOT_DIR):/opt/noteworthy --name noteworthy-dev-$(shell date +"%H-%M_%m-%d") noteworthy:dev
+	docker run --network noteworthy --rm -it -v /usr/local/bin/docker:/usr/local/bin/docker -v /var/run/docker.sock:/var/run/docker.sock -v $(ROOT_DIR):/opt/noteworthy --name noteworthy-dev-$(shell date +"%H-%M_%m-%d") noteworthy:dev;


### PR DESCRIPTION
Resolves #32 
turns out there was a bug in `gnulib` that broke `GNU Make 4.3` :-1:  
https://stackoverflow.com/questions/62561355/permission-error-running-any-git-command-in-makefiles/62562135#62562135

to work around this issue for anyone using an unpatched version of `GNU Make 4.3`, we can add semicolons to the end of our statements in the make file.

semicolon PR :1st_place_medal: 